### PR TITLE
making the location of gvm's groovysh more universal

### DIFF
--- a/src/main/lisp/malabar-variables.el
+++ b/src/main/lisp/malabar-variables.el
@@ -80,7 +80,7 @@ keybindings.  Changing this variable is at your own risk."
   :package-version '(malabar . "2.0")
   :type 'string)
 
-(defcustom malabar-groovy-grooysh "~/.gvm/groovy/2.3.7/bin/groovysh"
+(defcustom malabar-groovy-grooysh "~/.gvm/groovy/current/bin/groovysh"
   "Where to find the groovysh executable"
   :group 'malabar
   :package-version '(malabar . "2.0")


### PR DESCRIPTION
In my installation, I have version 2.4.0 and a symlink to 'current' there; I think having the symlink instead of hard-coded version should be more generic.
